### PR TITLE
Add GLUON_ATH10K_MESH for ATH10K targets

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -45,3 +45,5 @@ GLUON_LANGS ?= de en fr
 
 GLUON_TARGET ?= ar71xx-generic
 GLUON_BRANCH := stable
+
++GLUON_ATH10K_MESH ?= ibss


### PR DESCRIPTION
This enables the build of ath10k based hardware like the TP Link Archer C7v2 and the ubiquiti-unifi-ac within the ar71xx target.

This would allow us to move archer c7v2 nodes in your region to you firmware:
https://map.aachen.freifunk.net/#!v:m;n:60e327a65b51